### PR TITLE
Update Opportunity Models to Conform with Current STAT Spec

### DIFF
--- a/stat_fastapi/api.py
+++ b/stat_fastapi/api.py
@@ -7,7 +7,7 @@ from stat_fastapi.constants import TYPE_GEOJSON, TYPE_JSON
 from stat_fastapi.exceptions import ConstraintsException, NotFoundException
 from stat_fastapi.models.opportunity import (
     OpportunityCollection,
-    OpportunitySearch,
+    OpportunityRequest,
 )
 from stat_fastapi.models.order import Order
 from stat_fastapi.models.product import Product, ProductsCollection
@@ -146,7 +146,7 @@ class StatApiRouter:
         return product
 
     async def search_opportunities(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> OpportunityCollection:
         """
         Explore the opportunities available for a particular set of constraints
@@ -161,7 +161,7 @@ class StatApiRouter:
         )
 
     async def create_order(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> JSONResponse:
         """
         Create a new order.

--- a/stat_fastapi/backend.py
+++ b/stat_fastapi/backend.py
@@ -2,7 +2,7 @@ from typing import Protocol
 
 from fastapi import Request
 
-from stat_fastapi.models.opportunity import Opportunity, OpportunitySearch
+from stat_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stat_fastapi.models.order import Order
 from stat_fastapi.models.product import Product
 
@@ -20,7 +20,7 @@ class StatApiBackend(Protocol):
         """
 
     async def search_opportunities(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> list[Opportunity]:
         """
         Search for ordering opportunities for the  given search parameters.
@@ -29,7 +29,7 @@ class StatApiBackend(Protocol):
         `stat_fastapi.backend.exceptions.ConstraintsException` if not valid.
         """
 
-    async def create_order(self, search: OpportunitySearch, request: Request) -> Order:
+    async def create_order(self, search: OpportunityRequest, request: Request) -> Order:
         """
         Create a new order.
 

--- a/stat_fastapi/models/opportunity.py
+++ b/stat_fastapi/models/opportunity.py
@@ -12,11 +12,11 @@ from stat_fastapi.types.filter import CQL2Filter
 class OpportunityProperties(BaseModel):
     datetime: DatetimeInterval
     product_id: str
-    filter: Optional[CQL2Filter] = None
 
 
-class OpportunitySearch(OpportunityProperties):
+class OpportunityRequest(OpportunityProperties):
     geometry: Geometry
+    filter: Optional[CQL2Filter] = None
 
 
 class Opportunity(Feature[Geometry, OpportunityProperties]):

--- a/stat_fastapi_landsat/backend.py
+++ b/stat_fastapi_landsat/backend.py
@@ -14,7 +14,7 @@ from stat_fastapi.exceptions import NotFoundException
 from stat_fastapi.models.opportunity import (
     Opportunity,
     OpportunityProperties,
-    OpportunitySearch,
+    OpportunityRequest,
 )
 from stat_fastapi.models.order import Order
 from stat_fastapi.models.product import Product, Provider, ProviderRole
@@ -95,7 +95,7 @@ class StatLandsatBackend:
             raise NotFoundException() from exc
 
     async def search_opportunities(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> list[Opportunity]:
         """
         Search for ordering opportunities for the given search parameters.
@@ -146,7 +146,7 @@ class StatLandsatBackend:
 
         return opportunities
 
-    async def create_order(self, search: OpportunitySearch, request: Request) -> Order:
+    async def create_order(self, search: OpportunityRequest, request: Request) -> Order:
         """
         Create a new order.
         """

--- a/stat_fastapi_landsat/models.py
+++ b/stat_fastapi_landsat/models.py
@@ -3,12 +3,12 @@ from pydantic import (
 )
 
 from stat_fastapi.models.constraints import Constraints as BaseConstraints
-from stat_fastapi.models.opportunity import OpportunitySearch
+from stat_fastapi.models.opportunity import OpportunityRequest
 
 
 class Constraints(BaseConstraints):
     model_config = ConfigDict(extra="forbid")
 
 
-class ValidatedOpportunitySearch(OpportunitySearch):
+class ValidatedOpportunityRequest(OpportunityRequest):
     properties: Constraints

--- a/stat_fastapi_test_backend/backend.py
+++ b/stat_fastapi_test_backend/backend.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from fastapi import Request
 
 from stat_fastapi.exceptions import ConstraintsException, NotFoundException
-from stat_fastapi.models.opportunity import Opportunity, OpportunitySearch
+from stat_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stat_fastapi.models.order import Order
 from stat_fastapi.models.product import Product
 
@@ -12,7 +12,7 @@ from stat_fastapi.models.product import Product
 class TestBackend:
     _products: list[Product] = []
     _opportunities: list[Opportunity] = []
-    _allowed_payloads: list[OpportunitySearch] = []
+    _allowed_payloads: list[OpportunityRequest] = []
     _orders: Mapping[str, Order] = {}
 
     def products(self, request: Request) -> list[Product]:
@@ -34,11 +34,13 @@ class TestBackend:
             raise NotFoundException() from exc
 
     async def search_opportunities(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> list[Opportunity]:
         return [o.model_copy(update=search.model_dump()) for o in self._opportunities]
 
-    async def create_order(self, payload: OpportunitySearch, request: Request) -> Order:
+    async def create_order(
+        self, payload: OpportunityRequest, request: Request
+    ) -> Order:
         """
         Create a new order.
         """

--- a/stat_fastapi_tle_backend/backend.py
+++ b/stat_fastapi_tle_backend/backend.py
@@ -2,10 +2,10 @@ from fastapi import Request
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from stat_fastapi.exceptions import ConstraintsException, NotFoundException
-from stat_fastapi.models.opportunity import Opportunity, OpportunitySearch
+from stat_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stat_fastapi.models.order import Order
 from stat_fastapi.models.product import Product, Provider, ProviderRole
-from stat_fastapi_tle_backend.models import ValidatedOpportunitySearch
+from stat_fastapi_tle_backend.models import ValidatedOpportunityRequest
 from stat_fastapi_tle_backend.repository import Repository
 from stat_fastapi_tle_backend.satellite import EarthObservationSatelliteModel
 from stat_fastapi_tle_backend.settings import Settings
@@ -76,14 +76,14 @@ class StatMockBackend:
             raise NotFoundException() from exc
 
     async def search_opportunities(
-        self, search: OpportunitySearch, request: Request
+        self, search: OpportunityRequest, request: Request
     ) -> list[Opportunity]:
         """
         Search for ordering opportunities for the  given search parameters.
         """
         # Additional constraints validation according to this backend's constraints
         try:
-            validated = ValidatedOpportunitySearch(**search.model_dump(by_alias=True))
+            validated = ValidatedOpportunityRequest(**search.model_dump(by_alias=True))
         except ValidationError as exc:
             raise ConstraintsException(exc.errors()) from exc
 
@@ -115,12 +115,12 @@ class StatMockBackend:
         ]
         return opportunities
 
-    async def create_order(self, search: OpportunitySearch, request: Request) -> Order:
+    async def create_order(self, search: OpportunityRequest, request: Request) -> Order:
         """
         Create a new order.
         """
         try:
-            validated = ValidatedOpportunitySearch(**search.model_dump(by_alias=True))
+            validated = ValidatedOpportunityRequest(**search.model_dump(by_alias=True))
         except ValidationError as exc:
             raise ConstraintsException(exc.errors()) from exc
 

--- a/stat_fastapi_tle_backend/models.py
+++ b/stat_fastapi_tle_backend/models.py
@@ -11,7 +11,7 @@ from pydantic import (
 )
 
 from stat_fastapi.models.constraints import Constraints as BaseConstraints
-from stat_fastapi.models.opportunity import OpportunitySearch
+from stat_fastapi.models.opportunity import OpportunityRequest
 
 
 class Satellite(BaseModel):
@@ -74,5 +74,5 @@ class Constraints(BaseConstraints):
     model_config = ConfigDict(extra="forbid")
 
 
-class ValidatedOpportunitySearch(OpportunitySearch):
+class ValidatedOpportunityRequest(OpportunityRequest):
     properties: Constraints

--- a/stat_fastapi_tle_backend/repository.py
+++ b/stat_fastapi_tle_backend/repository.py
@@ -13,7 +13,7 @@ from sqlalchemy.pool import StaticPool
 from stat_fastapi.models.constraints import Constraints
 from stat_fastapi.models.order import Order
 
-from .models import OffNadirRange, ValidatedOpportunitySearch
+from .models import OffNadirRange, ValidatedOpportunityRequest
 
 logger = getLogger(__name__)
 
@@ -41,7 +41,7 @@ class OrderEntity(Base):
     )
 
     @classmethod
-    def from_search(cls, search: ValidatedOpportunitySearch) -> "OrderEntity":
+    def from_search(cls, search: ValidatedOpportunityRequest) -> "OrderEntity":
         order_id = str(uuid4())
         geom = from_geojson(search.geometry.model_dump_json(by_alias=True))
         return OrderEntity(
@@ -107,7 +107,7 @@ class Repository:
     def __exit__(self, exception_type, exception_value, exception_traceback):
         self.session.close()
 
-    def add_order(self, search: ValidatedOpportunitySearch) -> Order:
+    def add_order(self, search: ValidatedOpportunityRequest) -> Order:
         entity = OrderEntity.from_search(search)
         with self as session:
             session.add(entity)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from geojson_pydantic import Point
 from pydantic import BaseModel
 from pytest import fixture
 
-from stat_fastapi.models.opportunity import Opportunity, OpportunitySearch
+from stat_fastapi.models.opportunity import Opportunity, OpportunityRequest
 from stat_fastapi.models.product import Product, Provider, ProviderRole
 
 
@@ -53,7 +53,7 @@ def opportunities(products: list[Product]):
 @fixture
 def allowed_payloads(products: list[Product]):
     yield [
-        OpportunitySearch(
+        OpportunityRequest(
             geometry=Point(type="Point", coordinates=[13.4, 52.5]),
             product_id=products[0].id,
             datetime=(datetime.now(UTC), datetime.now(UTC)),

--- a/tests/order_test.py
+++ b/tests/order_test.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from httpx import Response
 from pytest import fixture
 
-from stat_fastapi.models.opportunity import OpportunitySearch
+from stat_fastapi.models.opportunity import OpportunityRequest
 from stat_fastapi_test_backend.backend import TestBackend
 
 from .utils import find_link
@@ -20,7 +20,7 @@ END = START + timedelta(days=5)
 def new_order_response(
     stat_backend: TestBackend,
     stat_client: TestClient,
-    allowed_payloads: list[OpportunitySearch],
+    allowed_payloads: list[OpportunityRequest],
 ) -> Generator[Response, None, None]:
     stat_backend._allowed_payloads = allowed_payloads
 


### PR DESCRIPTION
- `OpportunitySearch` is renamed to `OpportunityRequest`
  - This change is a bit messy, since this class is used all over, but it's probably good to conform to the naming of the spec.
- `filters` field is moved from `OpportunityProperties` to `OpportunitiesRequest`

See current relevant spec [here](https://github.com/Element84/stat-api-spec/tree/main/opportunity#opportunity-request).